### PR TITLE
fix: correct URI of remote odrl-json-ld context

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,3 +22,6 @@
 
 Robert Bosch GmbH
     Matthias Binzer <matthias.binzer@de.bosch.com>
+
+SAP SE
+    Arno Weiß <arno.weiss@sap.com>

--- a/example_usage_policy.json
+++ b/example_usage_policy.json
@@ -1,6 +1,6 @@
 {
     "@context": [
-        "https://www.w3.org/ns/odrl.jsonld",
+        "http://www.w3.org/ns/odrl.jsonld",
         {
             "cx-policy": "https://w3id.org/catenax/policy/"
         }


### PR DESCRIPTION
The EDC currently returns HTTP 400 when given the non-expanded example from this repository. This is because it includes `https://www.w3.org/ns/odrl.jsonld` as the URI for the ODRL-context. However, it is specfied with `http` and not `https` [1]. This is hardcoded in the EDC as it doesn't resolve the context remotely but locally [2]. For other json-ld parsers, this may not matter as the `http` URL is forwarded to `https`. 

This bug may have proliferated to other kits and internal documentation. In this repo, the example is the only instance I could find.

[1] https://www.w3.org/TR/odrl-vocab/#json-ld
[2] https://github.com/eclipse-edc/Connector/blob/9efa8adf191c471425ac7d1920c1d970ba277aeb/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java#L94