### PR TITLE
Updates/refinement 2408

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## [2408] - 2024-05-31
+- Purposes: Append 1 year as default
+- Purposes: Remove behaviortwin
+- Purposes: Add legal definition for:
+    - cx.core.digitalTwinRegistry:1
+    - cx.dcm.base:1
+    - cx.quality.base:1
+    - cx.pcf.base:1
+- FrameworkAgreement: Deprecated UC Frameworks and new Governance
+    Framework with 'valid from' and 'valid until' dates
+    Add new DataExchangeGovernance.
+- Purposes: cx.core.legalRequirementForThirdparty:1 clarified
+- Purposes: Update to latest official legal description. The previous version from the docs wasn't final.
+
+
+
+## [2405] - 2024-05-22
+
+- Update credential names to match standardized credential types. Instead of lower-casing the first letter, only 'Credential' is removed from the end and vice versa.
+Example: CircularEconomy (policy) -> CircularEconomyCredential (credential type)
+

--- a/profile.md
+++ b/profile.md
@@ -88,6 +88,10 @@ Status: deprecated
 
 Valid from: 2024-10-17
 
+Valid until:
+
+Status: published
+
 
 
 ### Definition (legally binding)
@@ -134,11 +138,29 @@ Version numbers are typically 1 digit.
 **cx.core.legalRequirementForThirdparty:1**
 &quot;Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules &amp; high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.core.industrycore:1**
 &quot;Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.core.qualityNotifications:1**
 &quot;The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.pcf.base:1**
 &quot;(i) sending and receiving product-specific CO2 data and related functionalities such as (but not limited to) certificate exchange and notifications, 
@@ -146,6 +168,12 @@ Version numbers are typically 1 digit.
 (iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 
 **cx.quality.base:1**
@@ -158,6 +186,12 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.dcm.base:1**
 &quot;(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities 
 (ii) early identification of imbalances resulting from demand and capacity comparison, 
@@ -165,6 +199,12 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 (iv) initiate a collaborative approach to solve imbalances.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.puris.base:1**
 &quot;Optimizing processes, which includes, without limitation, regular exchange
@@ -174,62 +214,182 @@ unit real-time information relating to production and/or logistics.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.circular.dpp:1**
 &quot;Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.circular.smc:1**
 &quot;Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.circular.marketplace:1**
 &quot;Buy, sell and/or procure  parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.circular.materialaccounting:1**
 &quot;Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.gate.upload:1**
 &quot;Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants (&quot;Golden Record&quot;) and for early warning services (value-added services, &quot;VASs&quot;). As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.gate.download:1**
 &quot;Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.pool:1**
 &quot;Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.dataquality.upload:1**
 &quot;Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.dataquality.download:1**
 &quot;Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.bdv.upload:1**
 &quot;Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.bdv.download:1**
 &quot;Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.fpd.upload:1**
 &quot;Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.fpd.download:1**
 &quot;Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.swd.upload:1**
 &quot;Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.swd.download:1**
 &quot;Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.nps.upload:1**
 &quot;Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.nps.download:1**
 &quot;Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.countryrisk:1**
 &quot;Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.core.digitalTwinRegistry:1**
 &quot;Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 
 

--- a/profile.md
+++ b/profile.md
@@ -118,7 +118,7 @@ Version numbers are typically 1 digit.
 
 #### Version 1.0 of the Traceability FrameworkAgreement (deprecated)
 
-purpose.trace.v1.TraceBattery : **Deprecated.** Use instead: cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1 (**under clarification**)
+purpose.trace.v1.TraceBattery : **Deprecated.** Use instead: cx.core.legalRequirementForThirdparty:1
 
 purpose.trace.v1.aspects : **Deprecated.** Use instead: cx.core.industrycore:1
 
@@ -128,8 +128,7 @@ ID 3.1 Trace : **Deprecated.** Not directly replaced. Use a more specific UsageP
 
 #### Version 1.0 of the FrameworkAgreements released for 2405
 
-cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
-(**under clarification**)
+**cx.core.legalRequirementForThirdparty:1**
 &quot;Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules &amp; high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.core.industrycore:1**

--- a/profile.md
+++ b/profile.md
@@ -107,6 +107,12 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.quality.base:1**
 
 **cx.dcm.base:1**
+&quot;(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities 
+(ii) early identification of imbalances resulting from demand and capacity comparison, 
+(iii) messages and notifications related to imbalances and to exchanged demand and capacity data, 
+(iv) initiate a collaborative approach to solve imbalances.
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.puris.base:1**
 &quot;Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;

--- a/profile.md
+++ b/profile.md
@@ -24,19 +24,55 @@ Version numbers depend on the document and are typically 2 digit (e.g. 1.0).
 
 **Traceability:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **Pcf:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
 
 **Quality:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **CircularEconomy:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
 
 **DemandCapacity:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **Puris:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
 
 **BusinessPartner:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **BehavioralTwin:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
+**DataExchangeGovernance:1.0**
+
+Valid from: 2024-10-17
 
 
 

--- a/profile.md
+++ b/profile.md
@@ -13,14 +13,12 @@ NO LEGAL DEFINITION YET
 https://w3id.org/catenax/policy/FrameworkAgreement
 
 ### Description (not binding)
-The framework the negotiation is based on. Also known as Usecase Framework.
-Please find the legal definitions from the published Usecase Frameworks here:
+The framework the negotiation is based on. Previously known as Usecase Framework, now, known as Data Exchange Governance:
 
 https://catena-x.net/en/catena-x-introduce-implement/governance-framework-for-data-space-operations
 
 Version numbers depend on the document and are typically 2 digit (e.g. 1.0).
 
-*FrameworkAgreement* as a leftOperand allows the following **DRAFT VERSION (depends on the release of the legal documents)** *rightOperand* values
 
 **Traceability:1.0**
 

--- a/profile.md
+++ b/profile.md
@@ -110,23 +110,12 @@ https://w3id.org/catenax/policy/UsagePurpose
 ### Description (not binding)
 Legally binding purpose description. Allowed are standardized rightOperand values and free text values.
 
-LEGALLY BINDING MEANING for version 1.x is defined in the corresponding Usecase Framework documents that are referenced via the **FrameworkAgreement**
-
-The following list is NOT complete and a (not legally binding) summary of the relevant parts from the FrameworkAgreements:
-
 Version numbers are typically 1 digit.
 
-#### Version 1.0 of the Traceability FrameworkAgreement (deprecated)
 
-purpose.trace.v1.TraceBattery : **Deprecated.** Use instead: cx.core.legalRequirementForThirdparty:1
 
-purpose.trace.v1.aspects : **Deprecated.** Use instead: cx.core.industrycore:1
+### Definition (legally binding)
 
-purpose.trace.v1.qualityanalysis : **Deprecated.** Use instead: cx.core.qualityNotifications:1
-
-ID 3.1 Trace : **Deprecated.** Not directly replaced. Use a more specific UsagePurpose.
-
-#### Version 1.0 of the FrameworkAgreements released for 2405
 
 **cx.core.legalRequirementForThirdparty:1**
 &quot;Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules &amp; high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
@@ -229,8 +218,4 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 &quot;Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 
-
-
-### Definition (legally binding)
-NO LEGAL DEFINITION YET.
 

--- a/profile.md
+++ b/profile.md
@@ -165,8 +165,6 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.bpdm.vas.countryrisk:1**
 &quot;Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
-**cx.behaviortwin.base:1**
-
 **cx.core.digitalTwinRegistry:1** : **under clarification**
 
 

--- a/profile.md
+++ b/profile.md
@@ -164,7 +164,12 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.puris.base:1**
-&quot;Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+&quot;Optimizing processes, which includes, without limitation, regular exchange
+of data to prevent and/or solve shortages in the supply chain, conducting
+plausibility checks against other sources and/or collecting information to facilitate sound decision making, all of the above in the context of predictive
+unit real-time information relating to production and/or logistics.
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.circular.dpp:1**
 &quot;Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;

--- a/profile.md
+++ b/profile.md
@@ -105,6 +105,14 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.pcf.base:1**
 
 **cx.quality.base:1**
+&quot;(i) Early identification of anomalies in the use of the product,
+(ii) collaborative root-cause analysis of a problem / error and determining corrective action, 
+(iii) component tracing to optimize technical actions (in combination with use case Traceability),
+(iv) confirming corrective action,
+(v) preventive field observation to detect anomalies, 
+(vi) processing notifications of quality alerts (&quot;&quot;supply chain bottom-up&quot;&quot;) and quality investigations (&quot;&quot;supply chain top-down&quot;&quot;) (possibly in combination with use case &quot;&quot;Traceability&quot;&quot;).
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.dcm.base:1**
 &quot;(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities 

--- a/profile.md
+++ b/profile.md
@@ -138,6 +138,8 @@ Version numbers are typically 1 digit.
 **cx.core.legalRequirementForThirdparty:1**
 &quot;Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules &amp; high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for: TractionBatteryCode
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -147,6 +149,16 @@ Status: published
 **cx.core.industrycore:1**
 &quot;Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+SerialPart,
+Batch,
+JustInSequencePart,
+SingleLevelBomAsBuilt,
+PartAsPlanned,
+SingleLevelBomAsPlanned,
+PartSiteInformationAsPlanned,
+UniqueIDPushAPI
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -155,6 +167,8 @@ Status: published
 
 **cx.core.qualityNotifications:1**
 &quot;The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: Notification API
 
 Valid from: 2024-06-20
 
@@ -168,6 +182,10 @@ Status: published
 (iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for:
+PCF Model,
+PCF Exchange API
 
 Valid from: 2024-06-20
 
@@ -186,6 +204,15 @@ Status: published
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+Fleet Vehicles,
+Quality Task,
+QualityTaskAttachment,
+PartsAnalysis,
+ManufacturedPartsQInformation,
+FleetDiagnosticData,
+FleetClaim
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -199,6 +226,12 @@ Status: published
 (iv) initiate a collaborative approach to solve imbalances.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for:
+Material Demand,
+WeekBasedCapacityGroup,
+IdBasedRequestForUpdate,
+IdBasedComment
 
 Valid from: 2024-06-20
 
@@ -214,6 +247,12 @@ unit real-time information relating to production and/or logistics.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+Item Stock,
+Short-Term Material Demand,
+Planned Production Output,
+Delivery Information
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -222,6 +261,10 @@ Status: published
 
 **cx.circular.dpp:1**
 &quot;Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for:
+Digital Product Pass,
+Battery Pass
 
 Valid from: 2024-06-20
 
@@ -232,6 +275,10 @@ Status: published
 **cx.circular.smc:1**
 &quot;Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+SMC-Calculated,
+SMC-Verifiable
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -240,6 +287,8 @@ Status: published
 
 **cx.circular.marketplace:1**
 &quot;Buy, sell and/or procure  parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: Market Place Offer
 
 Valid from: 2024-06-20
 
@@ -250,6 +299,8 @@ Status: published
 **cx.circular.materialaccounting:1**
 &quot;Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -258,6 +309,8 @@ Status: published
 
 **cx.bpdm.gate.upload:1**
 &quot;Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants (&quot;Golden Record&quot;) and for early warning services (value-added services, &quot;VASs&quot;). As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: Gate Data Model
 
 Valid from: 2024-06-20
 
@@ -268,6 +321,8 @@ Status: published
 **cx.bpdm.gate.download:1**
 &quot;Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for: Gate Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -276,6 +331,8 @@ Status: published
 
 **cx.bpdm.pool:1**
 &quot;Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: Pool Data Models
 
 Valid from: 2024-06-20
 
@@ -286,6 +343,8 @@ Status: published
 **cx.bpdm.vas.dataquality.upload:1**
 &quot;Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for: BP Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -294,6 +353,8 @@ Status: published
 
 **cx.bpdm.vas.dataquality.download:1**
 &quot;Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: DQD data Model
 
 Valid from: 2024-06-20
 
@@ -304,6 +365,10 @@ Status: published
 **cx.bpdm.vas.bdv.upload:1**
 &quot;Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+Gate Data Model,
+BDV Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -312,6 +377,8 @@ Status: published
 
 **cx.bpdm.vas.bdv.download:1**
 &quot;Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: BDV Data Model
 
 Valid from: 2024-06-20
 
@@ -322,6 +389,8 @@ Status: published
 **cx.bpdm.vas.fpd.upload:1**
 &quot;Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for: FP Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -330,6 +399,8 @@ Status: published
 
 **cx.bpdm.vas.fpd.download:1**
 &quot;Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: FP Data Model
 
 Valid from: 2024-06-20
 
@@ -340,6 +411,8 @@ Status: published
 **cx.bpdm.vas.swd.upload:1**
 &quot;Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for: Gate Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -348,6 +421,8 @@ Status: published
 
 **cx.bpdm.vas.swd.download:1**
 &quot;Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: SWD Data Model
 
 Valid from: 2024-06-20
 
@@ -358,6 +433,8 @@ Status: published
 **cx.bpdm.vas.nps.upload:1**
 &quot;Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for: Gate Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -366,6 +443,8 @@ Status: published
 
 **cx.bpdm.vas.nps.download:1**
 &quot;Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: NPS Data Model
 
 Valid from: 2024-06-20
 
@@ -376,6 +455,11 @@ Status: published
 **cx.bpdm.vas.countryrisk:1**
 &quot;Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
+Typically used for:
+Country Risk Data Model,
+Gate Data Model,
+Pool Data Models
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -384,6 +468,8 @@ Status: published
 
 **cx.core.digitalTwinRegistry:1**
 &quot;Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
+Typically used for: DTR Asset
 
 Valid from: 2024-06-20
 

--- a/profile.md
+++ b/profile.md
@@ -28,11 +28,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **Pcf:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **Quality:1.0**
 
@@ -40,11 +44,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **CircularEconomy:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **DemandCapacity:1.0**
 
@@ -52,11 +60,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **Puris:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **BusinessPartner:1.0**
 
@@ -64,11 +76,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **BehavioralTwin:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **DataExchangeGovernance:1.0**
 

--- a/profile.md
+++ b/profile.md
@@ -165,7 +165,8 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.bpdm.vas.countryrisk:1**
 &quot;Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
-**cx.core.digitalTwinRegistry:1** : **under clarification**
+**cx.core.digitalTwinRegistry:1**
+&quot;Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 
 

--- a/profile.md
+++ b/profile.md
@@ -94,13 +94,13 @@ ID 3.1 Trace : **Deprecated.** Not directly replaced. Use a more specific UsageP
 
 cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 (**under clarification**)
-&quot;Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules &amp; high-voltage batteries.&quot;
+&quot;Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules &amp; high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.core.industrycore:1**
-&quot;Establishing a digital representation of the automotive supply chain to enable a component specific data exchange.&quot;
+&quot;Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.core.qualityNotifications:1**
-&quot;The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers.&quot;
+&quot;The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.pcf.base:1**
 
@@ -109,61 +109,61 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.dcm.base:1**
 
 **cx.puris.base:1**
-&quot;Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics.&quot;
+&quot;Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.circular.dpp:1**
-&quot;Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports.&quot;
+&quot;Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.circular.smc:1**
-&quot;Exchanging information about secondary material content (SMC) to optimize SMC-usage.&quot;
+&quot;Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.circular.marketplace:1**
-&quot;Buy, sell and/or procure  parts and material.&quot;
+&quot;Buy, sell and/or procure  parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.circular.materialaccounting:1**
-&quot;Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain.&quot;
+&quot;Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.gate.upload:1**
-&quot;Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants (&quot;Golden Record&quot;) and for early warning services (value-added services, &quot;VASs&quot;).&quot;
+&quot;Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants (&quot;Golden Record&quot;) and for early warning services (value-added services, &quot;VASs&quot;). As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.gate.download:1**
-&quot;Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs.&quot;
+&quot;Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.pool:1**
-&quot;Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs.&quot;
+&quot;Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.dataquality.upload:1**
-&quot;Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application.&quot;
+&quot;Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.dataquality.download:1**
-&quot;Data Consumer assessing quality of own data.&quot;
+&quot;Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.bdv.upload:1**
-&quot;Screening relevant Data Provider's bank data to verify Data Provider's bank data.&quot;
+&quot;Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.bdv.download:1**
-&quot;Verifying Data Consumer's submitted bank data.&quot;
+&quot;Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.fpd.upload:1**
-&quot;Screening Data Provider's business partner data to assess fraud.&quot;
+&quot;Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.fpd.download:1**
-&quot;Data Consumer assessing fraud risks when transacting with another Participant.&quot;
+&quot;Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.swd.upload:1**
-&quot;Screening Data Provider's beneficial ownership data to assess trade compliance.&quot;
+&quot;Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.swd.download:1**
-&quot;Data Consumer assessing trade sanction risks when transacting with another Participant.&quot;
+&quot;Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.nps.upload:1**
-&quot;Verifying Data Provider's Business Partner Data against natural person data entries.&quot;
+&quot;Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.nps.download:1**
-&quot;Data Consumer verifying its own Business Partner Data.&quot;
+&quot;Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.bpdm.vas.countryrisk:1**
-&quot;Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments.&quot;
+&quot;Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.behaviortwin.base:1**
 

--- a/profile.md
+++ b/profile.md
@@ -103,6 +103,12 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 &quot;The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
 
 **cx.pcf.base:1**
+&quot;(i) sending and receiving product-specific CO2 data and related functionalities such as (but not limited to) certificate exchange and notifications, 
+(ii) conducting plausibility checks and validation measures,
+(iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.&quot;
+
 
 **cx.quality.base:1**
 &quot;(i) Early identification of anomalies in the use of the product,

--- a/profile.ttl
+++ b/profile.ttl
@@ -227,13 +227,13 @@ ID 3.1 Trace : **Deprecated.** Not directly replaced. Use a more specific UsageP
 
 cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 (**under clarification**)
-"Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries."
+"Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.core.industrycore:1**
-"Establishing a digital representation of the automotive supply chain to enable a component specific data exchange."
+"Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.core.qualityNotifications:1**
-"The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers."
+"The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.pcf.base:1**
 
@@ -242,61 +242,61 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.dcm.base:1**
 
 **cx.puris.base:1**
-"Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics."
+"Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.circular.dpp:1**
-"Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports."
+"Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.circular.smc:1**
-"Exchanging information about secondary material content (SMC) to optimize SMC-usage."
+"Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.circular.marketplace:1**
-"Buy, sell and/or procure  parts and material."
+"Buy, sell and/or procure  parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.circular.materialaccounting:1**
-"Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain."
+"Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.gate.upload:1**
-"Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants ("Golden Record") and for early warning services (value-added services, "VASs")."
+"Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants ("Golden Record") and for early warning services (value-added services, "VASs"). As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.gate.download:1**
-"Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs."
+"Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.pool:1**
-"Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs."
+"Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.dataquality.upload:1**
-"Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application."
+"Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.dataquality.download:1**
-"Data Consumer assessing quality of own data."
+"Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.bdv.upload:1**
-"Screening relevant Data Provider's bank data to verify Data Provider's bank data."
+"Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.bdv.download:1**
-"Verifying Data Consumer's submitted bank data."
+"Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.fpd.upload:1**
-"Screening Data Provider's business partner data to assess fraud."
+"Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.fpd.download:1**
-"Data Consumer assessing fraud risks when transacting with another Participant."
+"Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.swd.upload:1**
-"Screening Data Provider's beneficial ownership data to assess trade compliance."
+"Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.swd.download:1**
-"Data Consumer assessing trade sanction risks when transacting with another Participant."
+"Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.nps.upload:1**
-"Verifying Data Provider's Business Partner Data against natural person data entries."
+"Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.nps.download:1**
-"Data Consumer verifying its own Business Partner Data."
+"Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.bpdm.vas.countryrisk:1**
-"Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments."
+"Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.behaviortwin.base:1**
 

--- a/profile.ttl
+++ b/profile.ttl
@@ -240,6 +240,12 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.quality.base:1**
 
 **cx.dcm.base:1**
+"(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities 
+(ii) early identification of imbalances resulting from demand and capacity comparison, 
+(iii) messages and notifications related to imbalances and to exchanged demand and capacity data, 
+(iv) initiate a collaborative approach to solve imbalances.
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.puris.base:1**
 "Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."

--- a/profile.ttl
+++ b/profile.ttl
@@ -220,6 +220,10 @@ Status: deprecated
 
 Valid from: 2024-10-17
 
+Valid until:
+
+Status: published
+
 ''' ;
     skos:scopeNote "Catena-X" .
 
@@ -259,11 +263,29 @@ The rightOperand value for this is a free to choose reference under which both p
 **cx.core.legalRequirementForThirdparty:1**
 "Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.core.industrycore:1**
 "Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.core.qualityNotifications:1**
 "The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.pcf.base:1**
 "(i) sending and receiving product-specific CO2 data and related functionalities such as (but not limited to) certificate exchange and notifications, 
@@ -271,6 +293,12 @@ The rightOperand value for this is a free to choose reference under which both p
 (iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 
 **cx.quality.base:1**
@@ -283,6 +311,12 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.dcm.base:1**
 "(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities 
 (ii) early identification of imbalances resulting from demand and capacity comparison, 
@@ -290,6 +324,12 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 (iv) initiate a collaborative approach to solve imbalances.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.puris.base:1**
 "Optimizing processes, which includes, without limitation, regular exchange
@@ -299,62 +339,182 @@ unit real-time information relating to production and/or logistics.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.circular.dpp:1**
 "Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.circular.smc:1**
 "Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.circular.marketplace:1**
 "Buy, sell and/or procure  parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.circular.materialaccounting:1**
 "Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.gate.upload:1**
 "Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants ("Golden Record") and for early warning services (value-added services, "VASs"). As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.gate.download:1**
 "Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.pool:1**
 "Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.dataquality.upload:1**
 "Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.dataquality.download:1**
 "Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.bdv.upload:1**
 "Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.bdv.download:1**
 "Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.fpd.upload:1**
 "Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.fpd.download:1**
 "Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.swd.upload:1**
 "Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.swd.download:1**
 "Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.nps.upload:1**
 "Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.bpdm.vas.nps.download:1**
 "Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 **cx.bpdm.vas.countryrisk:1**
 "Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
+
 **cx.core.digitalTwinRegistry:1**
 "Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Valid from: 2024-06-20
+
+Valid until:
+
+Status: published
 
 ''';
     skos:note '''Legally binding purpose description. Allowed are standardized rightOperand values and free text values.

--- a/profile.ttl
+++ b/profile.ttl
@@ -156,19 +156,55 @@ Version numbers depend on the document and are typically 2 digit (e.g. 1.0).
 
 **Traceability:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **Pcf:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
 
 **Quality:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **CircularEconomy:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
 
 **DemandCapacity:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **Puris:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
 
 **BusinessPartner:1.0**
 
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
 **BehavioralTwin:1.0**
+
+Valid from: 2024-06-20
+
+Valid until: 2024-10-16
+
+**DataExchangeGovernance:1.0**
+
+Valid from: 2024-10-17
 
 ''' ;
     skos:scopeNote "Catena-X" .

--- a/profile.ttl
+++ b/profile.ttl
@@ -298,7 +298,8 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.bpdm.vas.countryrisk:1**
 "Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
-**cx.core.digitalTwinRegistry:1** : **under clarification**
+**cx.core.digitalTwinRegistry:1**
+"Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 
 ''' ;

--- a/profile.ttl
+++ b/profile.ttl
@@ -160,11 +160,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **Pcf:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **Quality:1.0**
 
@@ -172,11 +176,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **CircularEconomy:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **DemandCapacity:1.0**
 
@@ -184,11 +192,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **Puris:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **BusinessPartner:1.0**
 
@@ -196,11 +208,15 @@ Valid from: 2024-06-20
 
 Valid until: 2024-10-16
 
+Status: deprecated
+
 **BehavioralTwin:1.0**
 
 Valid from: 2024-06-20
 
 Valid until: 2024-10-16
+
+Status: deprecated
 
 **DataExchangeGovernance:1.0**
 

--- a/profile.ttl
+++ b/profile.ttl
@@ -298,8 +298,6 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.bpdm.vas.countryrisk:1**
 "Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
-**cx.behaviortwin.base:1**
-
 **cx.core.digitalTwinRegistry:1** : **under clarification**
 
 

--- a/profile.ttl
+++ b/profile.ttl
@@ -12,7 +12,7 @@
 	a owl:Ontology ;
 	rdfs:label "Catena-X Profile Ontology Version" ;
 	# version updates will be reflected here with e.g. 2405.1 for minor (append) updates once released
-	owl:versionInfo "2405" ;
+	owl:versionInfo "2408" ;
 	dct:creator "Matthias Binzer" ;
     dct:contributor "Catena-X Regulatory Framework Expert Group operating under the Data Space Operations Comitee" ;
 	dct:description "Defines what of ODRL is used and the legally binding term definitions." ;

--- a/profile.ttl
+++ b/profile.ttl
@@ -145,14 +145,12 @@
 	rdfs:isDefinedBy : ;
 	rdfs:label "FrameworkAgreement";
     skos:definition "NO LEGAL DEFINITION YET.";
-    skos:note '''The framework the negotiation is based on. Also known as Usecase Framework.
-Please find the legal definitions from the published Usecase Frameworks here:
+    skos:note '''The framework the negotiation is based on. Previously known as Usecase Framework, now, known as Data Exchange Governance:
 
 https://catena-x.net/en/catena-x-introduce-implement/governance-framework-for-data-space-operations
 
 Version numbers depend on the document and are typically 2 digit (e.g. 1.0).
 
-*FrameworkAgreement* as a leftOperand allows the following **DRAFT VERSION (depends on the release of the legal documents)** *rightOperand* values
 
 **Traceability:1.0**
 

--- a/profile.ttl
+++ b/profile.ttl
@@ -263,6 +263,8 @@ The rightOperand value for this is a free to choose reference under which both p
 **cx.core.legalRequirementForThirdparty:1**
 "Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for: TractionBatteryCode
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -272,6 +274,16 @@ Status: published
 **cx.core.industrycore:1**
 "Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+SerialPart,
+Batch,
+JustInSequencePart,
+SingleLevelBomAsBuilt,
+PartAsPlanned,
+SingleLevelBomAsPlanned,
+PartSiteInformationAsPlanned,
+UniqueIDPushAPI
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -280,6 +292,8 @@ Status: published
 
 **cx.core.qualityNotifications:1**
 "The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: Notification API
 
 Valid from: 2024-06-20
 
@@ -293,6 +307,10 @@ Status: published
 (iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for:
+PCF Model,
+PCF Exchange API
 
 Valid from: 2024-06-20
 
@@ -311,6 +329,15 @@ Status: published
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+Fleet Vehicles,
+Quality Task,
+QualityTaskAttachment,
+PartsAnalysis,
+ManufacturedPartsQInformation,
+FleetDiagnosticData,
+FleetClaim
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -324,6 +351,12 @@ Status: published
 (iv) initiate a collaborative approach to solve imbalances.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for:
+Material Demand,
+WeekBasedCapacityGroup,
+IdBasedRequestForUpdate,
+IdBasedComment
 
 Valid from: 2024-06-20
 
@@ -339,6 +372,12 @@ unit real-time information relating to production and/or logistics.
 
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+Item Stock,
+Short-Term Material Demand,
+Planned Production Output,
+Delivery Information
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -347,6 +386,10 @@ Status: published
 
 **cx.circular.dpp:1**
 "Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for:
+Digital Product Pass,
+Battery Pass
 
 Valid from: 2024-06-20
 
@@ -357,6 +400,10 @@ Status: published
 **cx.circular.smc:1**
 "Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+SMC-Calculated,
+SMC-Verifiable
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -365,6 +412,8 @@ Status: published
 
 **cx.circular.marketplace:1**
 "Buy, sell and/or procure  parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: Market Place Offer
 
 Valid from: 2024-06-20
 
@@ -375,6 +424,8 @@ Status: published
 **cx.circular.materialaccounting:1**
 "Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -383,6 +434,8 @@ Status: published
 
 **cx.bpdm.gate.upload:1**
 "Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants ("Golden Record") and for early warning services (value-added services, "VASs"). As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: Gate Data Model
 
 Valid from: 2024-06-20
 
@@ -393,6 +446,8 @@ Status: published
 **cx.bpdm.gate.download:1**
 "Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for: Gate Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -401,6 +456,8 @@ Status: published
 
 **cx.bpdm.pool:1**
 "Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: Pool Data Models
 
 Valid from: 2024-06-20
 
@@ -411,6 +468,8 @@ Status: published
 **cx.bpdm.vas.dataquality.upload:1**
 "Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for: BP Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -419,6 +478,8 @@ Status: published
 
 **cx.bpdm.vas.dataquality.download:1**
 "Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: DQD data Model
 
 Valid from: 2024-06-20
 
@@ -429,6 +490,10 @@ Status: published
 **cx.bpdm.vas.bdv.upload:1**
 "Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+Gate Data Model,
+BDV Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -437,6 +502,8 @@ Status: published
 
 **cx.bpdm.vas.bdv.download:1**
 "Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: BDV Data Model
 
 Valid from: 2024-06-20
 
@@ -447,6 +514,8 @@ Status: published
 **cx.bpdm.vas.fpd.upload:1**
 "Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for: FP Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -455,6 +524,8 @@ Status: published
 
 **cx.bpdm.vas.fpd.download:1**
 "Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: FP Data Model
 
 Valid from: 2024-06-20
 
@@ -465,6 +536,8 @@ Status: published
 **cx.bpdm.vas.swd.upload:1**
 "Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for: Gate Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -473,6 +546,8 @@ Status: published
 
 **cx.bpdm.vas.swd.download:1**
 "Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: SWD Data Model
 
 Valid from: 2024-06-20
 
@@ -483,6 +558,8 @@ Status: published
 **cx.bpdm.vas.nps.upload:1**
 "Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for: Gate Data Model
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -491,6 +568,8 @@ Status: published
 
 **cx.bpdm.vas.nps.download:1**
 "Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: NPS Data Model
 
 Valid from: 2024-06-20
 
@@ -501,6 +580,11 @@ Status: published
 **cx.bpdm.vas.countryrisk:1**
 "Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+Typically used for:
+Country Risk Data Model,
+Gate Data Model,
+Pool Data Models
+
 Valid from: 2024-06-20
 
 Valid until:
@@ -509,6 +593,8 @@ Status: published
 
 **cx.core.digitalTwinRegistry:1**
 "Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
+Typically used for: DTR Asset
 
 Valid from: 2024-06-20
 

--- a/profile.ttl
+++ b/profile.ttl
@@ -251,7 +251,7 @@ Version numbers are typically 1 digit.
 
 #### Version 1.0 of the Traceability FrameworkAgreement (deprecated)
 
-purpose.trace.v1.TraceBattery : **Deprecated.** Use instead: cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1 (**under clarification**)
+purpose.trace.v1.TraceBattery : **Deprecated.** Use instead: cx.core.legalRequirementForThirdparty:1
 
 purpose.trace.v1.aspects : **Deprecated.** Use instead: cx.core.industrycore:1
 
@@ -261,8 +261,7 @@ ID 3.1 Trace : **Deprecated.** Not directly replaced. Use a more specific UsageP
 
 #### Version 1.0 of the FrameworkAgreements released for 2405
 
-cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
-(**under clarification**)
+**cx.core.legalRequirementForThirdparty:1**
 "Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.core.industrycore:1**

--- a/profile.ttl
+++ b/profile.ttl
@@ -238,6 +238,14 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 **cx.pcf.base:1**
 
 **cx.quality.base:1**
+"(i) Early identification of anomalies in the use of the product,
+(ii) collaborative root-cause analysis of a problem / error and determining corrective action, 
+(iii) component tracing to optimize technical actions (in combination with use case Traceability),
+(iv) confirming corrective action,
+(v) preventive field observation to detect anomalies, 
+(vi) processing notifications of quality alerts (""supply chain bottom-up"") and quality investigations (""supply chain top-down"") (possibly in combination with use case ""Traceability"").
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.dcm.base:1**
 "(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities 

--- a/profile.ttl
+++ b/profile.ttl
@@ -297,7 +297,12 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.puris.base:1**
-"Optimising processes, conducting plausibility checks and/or collecting information to facilitate sound decision making, each in the context of predictive unit realtime information relating to production and/or logistics. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+"Optimizing processes, which includes, without limitation, regular exchange
+of data to prevent and/or solve shortages in the supply chain, conducting
+plausibility checks against other sources and/or collecting information to facilitate sound decision making, all of the above in the context of predictive
+unit real-time information relating to production and/or logistics.
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.circular.dpp:1**
 "Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."

--- a/profile.ttl
+++ b/profile.ttl
@@ -236,6 +236,12 @@ cx.core.legalRequirementForThirdparty:1 **or** cx.core.tractionbattery:1
 "The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
 **cx.pcf.base:1**
+"(i) sending and receiving product-specific CO2 data and related functionalities such as (but not limited to) certificate exchange and notifications, 
+(ii) conducting plausibility checks and validation measures,
+(iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
+
+As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
+
 
 **cx.quality.base:1**
 "(i) Early identification of anomalies in the use of the product,

--- a/profile.ttl
+++ b/profile.ttl
@@ -240,26 +240,7 @@ The rightOperand value for this is a free to choose reference under which both p
 :UsagePurpose
 	a odrl:LeftOperand, owl:NamedIndividual, skos:Concept ;
 	rdfs:label "UsagePurpose" ;
-	skos:definition "NO LEGAL DEFINITION YET.";    
-    skos:note '''Legally binding purpose description. Allowed are standardized rightOperand values and free text values.
-
-LEGALLY BINDING MEANING for version 1.x is defined in the corresponding Usecase Framework documents that are referenced via the **FrameworkAgreement**
-
-The following list is NOT complete and a (not legally binding) summary of the relevant parts from the FrameworkAgreements:
-
-Version numbers are typically 1 digit.
-
-#### Version 1.0 of the Traceability FrameworkAgreement (deprecated)
-
-purpose.trace.v1.TraceBattery : **Deprecated.** Use instead: cx.core.legalRequirementForThirdparty:1
-
-purpose.trace.v1.aspects : **Deprecated.** Use instead: cx.core.industrycore:1
-
-purpose.trace.v1.qualityanalysis : **Deprecated.** Use instead: cx.core.qualityNotifications:1
-
-ID 3.1 Trace : **Deprecated.** Not directly replaced. Use a more specific UsagePurpose.
-
-#### Version 1.0 of the FrameworkAgreements released for 2405
+	skos:definition '''
 
 **cx.core.legalRequirementForThirdparty:1**
 "Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
@@ -361,6 +342,10 @@ As a purpose-specific requirement, the duration of (i) contract, (ii) data provi
 **cx.core.digitalTwinRegistry:1**
 "Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year."
 
+''';
+    skos:note '''Legally binding purpose description. Allowed are standardized rightOperand values and free text values.
+
+Version numbers are typically 1 digit.
 
 ''' ;
 	


### PR DESCRIPTION
needs to go after #7 

All relevant changes for 2408 discussed in the meeting today with @HFocken and @KMA-2019

Especially relevant:
- The FrameworkAgreement changes and their 'Valid from / Valid until' fields
- the removal of 'behaviortwin' purpose.
- All purposes received a default for the 'how long' questions with 1 year!
