### PR TITLE
Workaround to easier use the example with tx-edc 0.7.3

### DIFF
--- a/example_usage_policy.json
+++ b/example_usage_policy.json
@@ -5,7 +5,7 @@
             "cx-policy": "https://w3id.org/catenax/policy/"
         }
     ],
-    "@type": "Policy",
+    "@type": "Set",
     "profile": "cx-policy:profile2405",
     "permission": [
         {

--- a/example_usage_policy_expanded.json
+++ b/example_usage_policy_expanded.json
@@ -1,7 +1,7 @@
 [
   {
     "@type": [
-      "http://www.w3.org/ns/odrl/2/Policy"
+      "http://www.w3.org/ns/odrl/2/Set"
     ],
     "http://www.w3.org/ns/odrl/2/permission": [
       {


### PR DESCRIPTION
The data management API of tx-edc (0.7.3) does not allow the type 'Policy' but requires 'Set'