### PR TITLE
feat: update CX policy for `BusinessPartnerNumber`, `BusinessPartnerGroup` and additional right operands 

### DIFF
--- a/profile-2506/README.md
+++ b/profile-2506/README.md
@@ -1,0 +1,7 @@
+# Catena-X ODRL Profile
+
+### Notes:
+The [profile-2506.ttl](profile-2506.ttl) file contains the updated version of Catena-X ODRL Profile.
+This includes the additional ODRL custom `LeftOperands`, `RightOperands`, and `Actions` decided by 
+Expert Group (Relevant Issues: [https://github.com/catenax-eV/cx-ex-data-sovereignty/issues/9](https://github.com/catenax-eV/cx-ex-data-sovereignty/issues/9),
+Discussion: [https://github.com/catenax-eV/cx-architecture/discussions/21](https://github.com/catenax-eV/cx-architecture/discussions/21)).

--- a/profile-2506/profile-2506.ttl
+++ b/profile-2506/profile-2506.ttl
@@ -205,20 +205,7 @@ cx::UsagePurpose
     skos:scopeNote   "Catena-X" .
 
 
-## Constraint Right Operands
 
-###  DataExchangeGovernance:1.0
-cx:DataExchangeGovernance:1.0
-    rdf:type         owl:NamedIndividual, skos:Concept, odrl:RightOperand ;
-    dct:description  "The Data Exchange Governance document set up by the Catena-X association. It governs the \"who, with whom, what, where from and where to, why, how, and when\" of Data Sharing in Catena-X. It is roughly structured along the lines of business scenarios under which a set of business partners want to exchange data." ;
-    dct:identifier   "https://w3id.org/catenax/policy/DataExchangeGovernance:1.0" ;
-    schema:status    "published" ;
-    schema:validFrom "2024-10-17"^^xsd:date ;
-    rdfs:isDefinedBy cx: ;
-    rdfs:label       "DataExchangeGovernance:1.0" ;
-    skos:definition  "NO LEGAL DEFINITION YET." ;
-    skos:note        "Allowed left operand(s): cx:FrameworkAgreement ." ;
-    skos:scopeNote   "Catena-X" .
 
 ## Actions for Policy
 
@@ -245,6 +232,380 @@ cx:usage
     skos:scopeNote   "Catena-X" ;
     odrl:includedIn  odrl:use .
 
+
+## Constraint Right Operands
+
+###  DataExchangeGovernance:1.0
+cx:DataExchangeGovernance:1.0
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:RightOperand ;
+    dct:description  "The Data Exchange Governance document set up by the Catena-X association. It governs the \"who, with whom, what, where from and where to, why, how, and when\" of Data Sharing in Catena-X. It is roughly structured along the lines of business scenarios under which a set of business partners want to exchange data." ;
+    dct:identifier   "https://w3id.org/catenax/policy/DataExchangeGovernance:1.0" ;
+    schema:status    "published" ;
+    schema:validFrom "2024-10-17"^^xsd:date ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "DataExchangeGovernance:1.0" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        "Allowed left operand(s): cx:FrameworkAgreement ." ;
+    skos:scopeNote   "Catena-X" .
+
+
+cx:cx.core.legalRequirementForThirdparty:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.core.legalRequirementForThirdparty:1" ;
+    rdfs:label "Legal Requirement For Third Party" ;
+    dct:description "Facilitating compliance with mandatory regulatory requirements for tracking and reporting battery cells, modules & high-voltage batteries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed right operand literals(s): cx:UsagePurpose ;
+                Typically used for: TractionBatteryCode""" .
+
+
+# 2
+cx:cx.core.industrycore:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.core.industrycore:1" ;
+    rdfs:label "Industrycore" ;
+    dct:description "Establishing a digital representation of the automotive supply chain to enable a component specific data exchange. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: SerialPart, Batch, JustInSequencePart, SingleLevelBomAsBuilt, PartAsPlanned, SingleLevelBomAsPlanned, PartSiteInformationAsPlanned, UniqueIDPushAPI""" .
+
+# 3
+cx:cx.core.qualityNotifications:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.core.qualityNotifications:1" ;
+    rdfs:label "Quality Notifications" ;
+    dct:description "The data can be used for quality analysis to identify and select affected components and to send quality notifications to affected customers or suppliers. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Notification API""" .
+
+
+
+# 4
+cx:cx.pcf.base:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.pcf.base:1" ;
+    rdfs:label "Base" ;
+    dct:description """(i) Sending and receiving product-specific CO2 data and related functionalities such as (but not limited to) certificate exchange and notifications,
+                       (ii) Conducting plausibility checks and validation measures,
+                       (iii) calculating aggregated PCFs of Data Consumer (including calculations operated by a technical service provider that (a) is certified for Catena-X, (b) is not authorized to evaluate data beyond such calculation and (c) provides calculations exclusively for Data Consumer's own purposes).
+        As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.
+""" ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: PCF Model, PCF Exchange API""" .
+
+
+# 5
+cx:cx.quality.base:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.quality.base:1" ;
+    rdfs:label "Quality Base" ;
+    dct:description "(i) Early identification of anomalies in the use of the product, (ii) collaborative root-cause analysis of a problem / error and determining corrective action, (iii) component tracing to optimize technical actions (in combination with use case Traceability), (iv) confirming corrective action, (v) preventive field observation to detect anomalies, (vi) processing notifications of quality alerts (" ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Fleet Vehicles, Quality Task, QualityTaskAttachment, PartsAnalysis, ManufacturedPartsQInformation, FleetDiagnosticData, FleetClaim""" .
+
+
+# 6
+cx:cx.dcm.base:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.dcm.base:1" ;
+    rdfs:label "DCM Base" ;
+    dct:description """(i) Sending and receiving product-specific demand and capacity data, as well as the associated product functionalities,
+                       (ii) early identification of imbalances resulting from demand and capacity comparison,
+                       (iii) messages and notifications related to imbalances and to exchanged demand and capacity data,
+                       (iv) initiate a collaborative approach to solve imbalances.
+        As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.""" ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Material Demand, WeekBasedCapacityGroup, IdBasedRequestForUpdate, IdBasedComment""" .
+
+
+# 7
+cx:cx.puris.base:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.puris.base:1" ;
+    rdfs:label "Puris Base" ;
+    dct:description """Optimizing processes, which includes, without limitation, regular exchange of data to prevent and/or solve shortages in the supply chain, conducting plausibility checks against other sources and/or collecting information to facilitate sound decision making, all of the above in the context of predictive unit real-time information relating to production and/or logistics.
+        As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year.""" ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Item Stock, Short-Term Material Demand, Planned Production Output, Delivery Information""" .
+
+
+# 8
+
+cx:cx.circular.dpp:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.circular.dpp:1" ;
+    rdfs:label "Circular DPP" ;
+    dct:description "Exchange and use of data according to the applicable public legal regulation directly requiring digital product passports or affecting the contents or handling of digital product passports. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Digital Product Pass, Battery Pass""" .
+
+# 9
+cx:cx.circular.smc:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.circular.smc:1" ;
+    rdfs:label "Circular SMC" ;
+    dct:description "Exchanging information about secondary material content (SMC) to optimize SMC-usage. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year" ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: SMC-Calculated, SMC-Verifiable""" .
+
+# 10
+cx:cx.circular.marketplace:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.circular.marketplace:1" ;
+    rdfs:label "Circular Marketplace" ;
+    dct:description "Buy, sell and/or procure parts and material. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Market Place Offer""" .
+
+# 11
+cx:cx.circular.materialaccounting:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.circular.materialaccounting:1" ;
+    rdfs:label "Circular Material Accounting" ;
+    dct:description "Display, process, analysis, correlate, modify and amend data. Use of data for (e.g. enablement of) chain of custody processes and commercial transaction related thereto and allocation of material to parts to the supply chain. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for:""" .
+
+# 12
+cx:cx.bpdm.gate.upload:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.gate.upload:1" ;
+    rdfs:label "BPDM Gate Upload" ;
+    dct:description "Verifying, curating and enriching data to create a record of basic information about all entities with a BPN in the CX Data Space accessible to all Participants (" ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Gate Data Model""" .
+
+# 13
+cx:cx.bpdm.gate.download:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.gate.download:1" ;
+    rdfs:label "BPDM Gate Download" ;
+    dct:description "Providing basic information about entities with a BPN in the CX Data Space for Data Consumer to identify counterparty and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Gate Data Model""" .
+
+# 14
+cx:cx.bpdm.pool:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.pool:1" ;
+    rdfs:label "BPDM Pool" ;
+    dct:description "Identifying Participants within the CX Data Space for Data Consumer's internal counterparty identification and information processes and/or for VASs. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Pool Data Models""" .
+
+# 15
+cx:cx.bpdm.vas.dataquality.upload:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.dataquality.upload:1" ;
+    rdfs:label "BPDM Vase Data Quality Upload" ;
+    dct:description "Screening Data Provider's data (i) to assess Data Provider's data quality and (ii) to create benchmarks for future screenings of other Participants' data by Data Consumer to fulfill the goals of the DQD application. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: BP Data Model""" .
+
+# 16
+cx:cx.bpdm.vas.dataquality.download:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.dataquality.download:1" ;
+    rdfs:label "BPDM Vase Data Quality Download" ;
+    dct:description "Data Consumer assessing quality of own data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: DQD data Model""" .
+
+# 17
+cx:cx.bpdm.vas.bdv.upload:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.bdv.upload:1" ;
+    rdfs:label "BPDM Vas BDV Upload" ;
+    dct:description "Screening relevant Data Provider's bank data to verify Data Provider's bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Gate Data Model, BDV Data Model""" .
+
+# 18
+cx:cx.bpdm.vas.bdv.download:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.bdv.download:1" ;
+    rdfs:label "BPDM Vas BDV Download" ;
+    dct:description "Verifying Data Consumer's submitted bank data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: BDV Data Model""" .
+
+
+# 19
+cx:cx.bpdm.vas.fpd.upload:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.fpd.upload:1" ;
+    rdfs:label "BPDM Vas FPD Upload" ;
+    dct:description "Screening Data Provider's business partner data to assess fraud. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: FP Data Model""" .
+
+
+# 20
+cx:cx.bpdm.vas.fpd.download:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.fpd.download:1" ;
+    rdfs:label "BPDM Vas FPD Download" ;
+    dct:description "Data Consumer assessing fraud risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: FP Data Model""" .
+
+# 21
+cx:cx.bpdm.vas.swd.upload:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.swd.upload:1" ;
+    rdfs:label "BPDM Vas SWD Upload" ;
+    dct:description "Screening Data Provider's beneficial ownership data to assess trade compliance. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Gate Data Model""" .
+
+# 22
+cx:cx.bpdm.vas.swd.download:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.swd.download:1" ;
+    rdfs:label "BPDM Vas SWD Download" ;
+    dct:description "Data Consumer assessing trade sanction risks when transacting with another Participant. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: SWD Data Model""" .
+
+# 23
+cx:cx.bpdm.vas.nps.upload:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.nps.upload:1" ;
+    rdfs:label "BPDM Vas NPS Upload" ;
+    dct:description "Verifying Data Provider's Business Partner Data against natural person data entries. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Gate Data Model""" .
+
+# 24
+cx:cx.bpdm.vas.nps.download:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.nps.download:1" ;
+    rdfs:label "BPDM Vas NPS Download" ;
+    dct:description "Data Consumer verifying its own Business Partner Data. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: NPS Data Model""" .
+
+
+# 25
+cx:cx.bpdm.vas.countryrisk:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.bpdm.vas.countryrisk:1" ;
+    rdfs:label "BPDM Vas Country Risk" ;
+    dct:description "Screening Participants’ business data to identify risks when collaborating with a new/existing business partner according to official or company-specific country risk assessments. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: Country Risk Data Model, Gate Data Model, Pool Data Models""" .
+
+
+# 26
+cx:cx.core.digitalTwinRegistry:1
+    a odrl:RightOperand, owl:NamedIndividual, skos:Concept ;
+    rdfs:isDefinedBy cx: ;
+    dct:identifier   "https://w3id.org/catenax/policy/cx.core.digitalTwinRegistry:1" ;
+    rdfs:label "Digital Twin Registry" ;
+    dct:description "Identifying data offers of submodels within the Catena-X ecosystem. As a purpose-specific requirement, the duration of (i) contract, (ii) data provision and (iii) usage right(s) as a default are all specified as 1 year." ;
+    skos:definition "NO LEGAL DEFINITION YET." ;
+    schema:validFrom "2024-06-20"^^xsd:date ;
+    schema:status "published" ;
+    skos:note """Allowed left operand(s): cx:UsagePurpose ;
+                Typically used for: DTR Asset""" .
 
 #################################################################
 #    Annotation properties

--- a/profile-2506/profile-2506.ttl
+++ b/profile-2506/profile-2506.ttl
@@ -1,0 +1,311 @@
+@base <https://w3id.org/catenax/policy/> .
+@prefix cx:     <https://w3id.org/catenax/policy/> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix odrl:   <http://www.w3.org/ns/odrl/2/> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:   <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+
+
+cx:
+    a        owl:Ontology ;
+    dct:contributor "Data Space Operations Committee" ;
+    dct:creator     "Catena-X Regulatory Framework Expert Group" ;
+    dct:description "This is the Catena-X ODRL Profile for Version 2405." ;
+    dct:license     <> ;
+    dct:title       "Catena-X ODRL Profile" ;
+    owl:versionInfo "2506" .
+
+## SKOS Collection
+cx:profile-2506
+    a              skos:Collection ;
+    skos:prefLabel "Catena-X ODRL Profile for Release 25.06 (and future use)" ;
+    skos:scopeNote "This is the supported set of definitions used in Catena-X. If parties agree on additional parts of the ODRL language, it is their choice." ;
+    ####
+    # ODRL Core
+    # https://github.com/w3c/odrl/blob/master/core-profile/odrl-core-profile-22.ttl
+    # reduced by the members in the area that are used in CX 2405,
+    # namely LogicalConstraint Operands and Constraint Operands (commented out below to easier track those)
+    #
+    ## Policy
+    skos:member    odrl:Policy ;
+    skos:member    odrl:uid ;
+    skos:member    odrl:profile ;
+    skos:member    odrl:inheritFrom ;
+    ## Policy Subclasses
+    skos:member    odrl:Agreement ;
+    skos:member    odrl:Offer ;
+    skos:member    odrl:Set ;
+    ## Rule
+    skos:member    odrl:Rule ;
+    skos:member    odrl:relation ;
+    skos:member    odrl:function ;
+    skos:member    odrl:failure ;
+    ## Asset and Relations
+    skos:member    odrl:Asset ;
+    skos:member    odrl:AssetCollection ;
+    skos:member    odrl:target ;
+    skos:member    odrl:hasPolicy ;
+    ## Party and Functions
+    skos:member    odrl:Party ;
+    skos:member    odrl:PartyCollection ;
+    skos:member    odrl:assignee ;
+    skos:member    odrl:assigner ;
+    skos:member    odrl:assigneeOf ;
+    skos:member    odrl:assignerOf ;
+    ## Asset and Party
+    skos:member    odrl:partOf ;
+    skos:member    odrl:source ;
+    ## Permission
+    skos:member    odrl:Permission ;
+    skos:member    odrl:permission ;
+    ## Prohibition
+    skos:member    odrl:Prohibition ;
+    skos:member    odrl:prohibition ;
+    ## Action
+    skos:member    odrl:Action ;
+    skos:member    odrl:action ;
+    skos:member    odrl:includedIn ;
+    skos:member    odrl:implies ;
+    ## Action for Rules
+    skos:member    odrl:use ;
+    skos:member    odrl:transfer ;
+    ## Duty
+    skos:member    odrl:Duty ;
+    skos:member    odrl:obligation ;
+    skos:member    odrl:duty ;
+    skos:member    odrl:consequence ;
+    skos:member    odrl:remedy ;
+    ## Constraint
+    skos:member    odrl:Constraint ;
+    skos:member    odrl:constraint ;
+    skos:member    odrl:refinement ;
+    skos:member    odrl:Operator ;
+    skos:member    odrl:operator ;
+    skos:member    odrl:RightOperand ;
+    skos:member    odrl:rightOperand ;
+    skos:member    odrl:rightOperandReference ;
+    skos:member    odrl:LeftOperand ;
+    skos:member    odrl:leftOperand ;
+    skos:member    odrl:unit ;
+    skos:member    odrl:dataType ;
+    skos:member    odrl:status ;
+    ## Logical Constraint
+    skos:member    odrl:LogicalConstraint ;
+    skos:member    odrl:operand ;
+    ## Constraint Operands
+    # not all are supported in CX 2506
+    skos:member    odrl:eq ;
+    skos:member    odrl:isAnyOf ;
+    skos:member    odrl:isNoneOf ;
+    ## Logical Constraint Operands
+    # not all are allowed in CX 2506
+    skos:member    odrl:and ;
+    skos:member    odrl:ConflictTerm ;
+    skos:member    odrl:conflict ;
+    skos:member    odrl:perm ;
+    skos:member    odrl:prohibit ;
+    skos:member    odrl:invalid ;
+    #
+    ####
+    # Catena-X ODRL Profile Vocabulary Terms
+    ####
+    # Constraint Left Operands
+    skos:member    cx:FrameworkAgreement ;
+    skos:member    cx:Membership ;
+    skos:member    cx:ContractReference ;
+    skos:member    cx:UsagePurpose ;
+    skos:member    cx:BusinessPartnerNumber ;
+    skos:member    cx:BusinessPartnerGroup ;
+    # Actions for Policy
+    skos:member    cx:access ;
+    skos:member    cx:usage ;
+    # Constraint Right Operands
+    skos:member    cx:DataExchangeGovernance:1.0 .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+## Constraint Left Operands
+
+###  BusinessPartnerGroup
+cx:BusinessPartnerGroup
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:LeftOperand ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "BusinessPartnerGroup" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        "Allowed operator(s): odrl:isAnyOf, odrl:isNoneOf ." ;
+    skos:scopeNote   "Catena-X" .
+
+
+###  BusinessPartnerNumber
+cx:BusinessPartnerNumber
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:LeftOperand ;
+    dct:description  "BPN, the unique identifier that is assigned to each business partner." ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "BusinessPartnerNumber" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        "Allowed operator(s): odrl:eq ." ;
+    skos:scopeNote   "Catena-X" .
+
+
+###  ContractReference
+cx:ContractReference
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:LeftOperand ;
+    dct:description  "References contracts that are not governed by the Catena-X association." ;
+    dct:identifier   "" ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "ContractReference" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        "Allowed operator(s): odrl:eq ." ;
+    skos:scopeNote   "Catena-X" .
+
+
+###  FrameworkAgreement
+cx:FrameworkAgreement
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:LeftOperand ;
+    dct:description  "References the legally binding Data Exchange Governance document set up by the Catena-X association." ;
+    dct:identifier   "https://w3id.org/catenax/policy/FrameworkAgreement" ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "FrameworkAgreement" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        """Allowed operator(s): odrl:eq ;
+Allowed right operand literals(s): \"DataExchangeGovernance:1.0\"""" ;
+    skos:scopeNote   "Catena-X" .
+
+
+###  Membership
+cx:Membership
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:LeftOperand ;
+    dct:description  "Status of membership in the Dataspace." ;
+    dct:identifier   "https://w3id.org/catenax/policy/Membership" ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "Membership" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        """Allowed operator(s): odrl:eq ;
+
+Allowed right operand literals(s): \"active\"""" ;
+    skos:scopeNote   "Catena-X" .
+
+
+###  UsagePurpose
+cx::UsagePurpose
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:LeftOperand ;
+    dct:description  "Restricts the purpose the Consumer is privileged to use the obtained data for" ;
+    dct:identifier   "" ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "UsagePurpose" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        "Allowed operator(s): odrl:eq ." ;
+    skos:scopeNote   "Catena-X" .
+
+
+## Constraint Right Operands
+
+###  DataExchangeGovernance:1.0
+cx:DataExchangeGovernance:1.0
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:RightOperand ;
+    dct:description  "The Data Exchange Governance document set up by the Catena-X association. It governs the \"who, with whom, what, where from and where to, why, how, and when\" of Data Sharing in Catena-X. It is roughly structured along the lines of business scenarios under which a set of business partners want to exchange data." ;
+    dct:identifier   "https://w3id.org/catenax/policy/DataExchangeGovernance:1.0" ;
+    schema:status    "published" ;
+    schema:validFrom "2024-10-17"^^xsd:date ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "DataExchangeGovernance:1.0" ;
+    skos:definition  "NO LEGAL DEFINITION YET." ;
+    skos:note        "Allowed left operand(s): cx:FrameworkAgreement ." ;
+    skos:scopeNote   "Catena-X" .
+
+## Actions for Policy
+
+###  access
+cx:access
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:Action ;
+    dct:identifier   "https://w3id.org/catenax/policy/access" ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "Access" ;
+    skos:definition  "An access policy-level action." ;
+    skos:note        "This action MUST only be used with an Access policy and directly on that policy (not inside Rules)." ;
+    skos:scopeNote   "Catena-X" ;
+    odrl:includedIn  odrl:use .
+
+
+###  usage
+cx:usage
+    rdf:type         owl:NamedIndividual, skos:Concept, odrl:Action ;
+    dct:identifier   "https://w3id.org/catenax/policy/usage" ;
+    rdfs:isDefinedBy cx: ;
+    rdfs:label       "Usage" ;
+    skos:definition  "A usage policy-level action." ;
+    skos:note        "This action MUST only be used with an Usage policy and directly on that policy (not inside Rules)." ;
+    skos:scopeNote   "Catena-X" ;
+    odrl:includedIn  odrl:use .
+
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+dct:contributor
+    rdf:type owl:AnnotationProperty .
+
+dct:creator
+    rdf:type owl:AnnotationProperty .
+
+dct:description
+    rdf:type owl:AnnotationProperty .
+
+dct:identifier
+    rdf:type owl:AnnotationProperty .
+
+dct:license
+    rdf:type owl:AnnotationProperty .
+
+dct:title
+    rdf:type owl:AnnotationProperty .
+
+schema:status
+    rdf:type owl:AnnotationProperty .
+
+schema:validFrom
+    rdf:type owl:AnnotationProperty .
+
+skos:definition
+    rdf:type owl:AnnotationProperty .
+
+skos:member
+    rdf:type owl:AnnotationProperty .
+
+skos:note
+    rdf:type owl:AnnotationProperty .
+
+skos:prefLabel
+    rdf:type owl:AnnotationProperty .
+
+skos:scopeNote
+    rdf:type owl:AnnotationProperty .
+
+odrl:includedIn
+    rdf:type owl:AnnotationProperty .
+
+xsd:date
+    rdf:type rdfs:Datatype .
+
+skos:Collection
+    rdf:type owl:Class .
+
+skos:Concept
+    rdf:type owl:Class .
+
+odrl:Action
+    rdf:type owl:Class .
+
+odrl:LeftOperand
+    rdf:type owl:Class .
+
+odrl:RightOperand
+    rdf:type owl:Class .


### PR DESCRIPTION
Adds the [profile-2506.ttl](profile-2506.ttl) file, which includes additional ODRL `LeftOperands`, for `BusinessPartnerNumber` and `BusinessPartnerGroup`. It also includes `RightOperand` resources, and `Action`s decided by 
Expert Group. (Relevant Issues: https://github.com/catenax-eV/cx-ex-data-sovereignty/issues/9, Discussion: https://github.com/catenax-eV/cx-architecture/discussions/21).