### PR TITLE
Update atomic-constraint-schemas.json

### DIFF
--- a/schema/atomic-constraint-schemas.json
+++ b/schema/atomic-constraint-schemas.json
@@ -193,7 +193,7 @@
         }
       ]
     },
-        "AtomicProhibitionConstraint": {
+    "AtomicProhibitionConstraint": {
       "allOf": [
         {
           "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"

--- a/schema/atomic-constraint-schemas.json
+++ b/schema/atomic-constraint-schemas.json
@@ -148,6 +148,23 @@
           "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"
         },
         {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AtomicAccessObligationConstraint"
+            },
+            {
+              "$ref": "#/definitions/AtomicUsageObligationConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    "AtomicAccessObligationConstraint": {
+      "allOf": [
+        {
+          "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"
+        },
+        {
           "oneOf": [
             {
               "$ref": "https://w3id.org/catenax/2025/9/policy/data-provisioning-end-duration-days-constraint-schema.json"
@@ -159,7 +176,61 @@
         }
       ]
     },
-    "AtomicProhibitionConstraint": {
+    "AtomicUsageObligationConstraint": {
+      "allOf": [
+        {
+          "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "https://w3id.org/catenax/2025/9/policy/data-provisioning-end-duration-days-constraint-schema.json"
+            },
+            {
+              "$ref": "https://w3id.org/catenax/2025/9/policy/data-provisioning-end-date-constraint-schema.json"
+            }
+          ]
+        }
+      ]
+    },
+        "AtomicProhibitionConstraint": {
+      "allOf": [
+        {
+          "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"
+        },
+        {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AtomicAccessProhibitionConstraint"
+            },
+            {
+              "$ref": "#/definitions/AtomicUsageProhibitionConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    "AtomicAccessProhibitionConstraint": {
+      "allOf": [
+        {
+          "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"
+        },
+        {
+          "anyOf": [
+            {
+              "$ref": "https://w3id.org/catenax/2025/9/policy/affiliates-region-constraint-schema.json"
+            },
+            {
+              "$ref": "https://w3id.org/catenax/2025/9/policy/affiliates-bpnl-constraint-schema.json"
+            },
+            {
+              "$ref": "https://w3id.org/catenax/2025/9/policy/usage-restriction-constraint-schema.json"
+            }
+          ]
+        }
+      ]
+    },
+        "AtomicUsageProhibitionConstraint": {
       "allOf": [
         {
           "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/AtomicConstraint"


### PR DESCRIPTION
i noticed that we miss the differentiation between usage and access for prohibition and permission.
at least for consistency reasons we should add this.

**NOTE: the constraints are the same for usage and access at the moment as i am not aware what constraints are allowed in a usage/access level of a prohibition,obligation. this needs to be updated in the PR **