### PR TITLE
fix: policy schema ref links

### DIFF
--- a/schema/atomic-constraint-schemas.json
+++ b/schema/atomic-constraint-schemas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "title": "AtomicCatenaXConstraintSchema",
   "type": "object",
   "allOf": [

--- a/schema/policy-schema.json
+++ b/schema/policy-schema.json
@@ -209,7 +209,7 @@
           "$ref": "#/definitions/UsagePermissionLogicalConstraint"
         },
         {
-          "$ref": "https://w3id.org/catenax/2025/9/policy/atomic-constraint-schemas.json#/definitions/AtomicUsagePermissionConstraint"
+          "$ref": "https://w3id.org/catenax/2025/9/policy/schema/atomic-constraint-schemas.json#/definitions/AtomicUsagePermissionConstraint"
         }
       ]
     },
@@ -234,7 +234,7 @@
           "$ref": "#/definitions/UsageProhibitionLogicalConstraint"
         },
         {
-          "$ref": "https://w3id.org/catenax/2025/9/policy/atomic-constraint-schemas.json#/definitions/AtomicProhibitionConstraint"
+          "$ref": "https://w3id.org/catenax/2025/9/policy/schema/atomic-constraint-schemas.json#/definitions/AtomicProhibitionConstraint"
         }
       ]
     },


### PR DESCRIPTION
Some of the ref links are invalid. These are the first errors I stumbled upon, there may be more errors on deeper levels that I haven't checked so far.